### PR TITLE
Fix the way of validating the id existance.

### DIFF
--- a/assets/js/jquery.stoocky-page.js
+++ b/assets/js/jquery.stoocky-page.js
@@ -96,7 +96,7 @@
 
             $('section').each(function(){
 
-                if ($(this).attr('id') != '') {
+                if ($(this).attr('id')) {
 
                     /*
                      * Make props accessible


### PR DESCRIPTION
If an element doesn't have ID, it returns 'undefined', so the previous validation for empty string isn't correct.